### PR TITLE
StacDBReplayClient fix cosmetic NPEs, SOCJoinGameAuth.parseDataStr compat

### DIFF
--- a/src/main/java/soc/client/SOCReplayPanel.java
+++ b/src/main/java/soc/client/SOCReplayPanel.java
@@ -138,7 +138,7 @@ public class SOCReplayPanel extends Panel implements ActionListener
         
         toTurnBut.setSize(butW, lineH);
         toTurnBut.setLocation(buttonMargin * 4 + butW * 3, curY);
-        toTurnBut.setEnabled(true);
+        toTurnBut.setEnabled(! (rcl instanceof StacDBReplayClient));
         
         curY += lineH + margin;
         toBrkBut.setSize(butW, lineH);
@@ -178,5 +178,13 @@ public class SOCReplayPanel extends Panel implements ActionListener
         	rcl.toBreakPoint(brkText.getText());
         }
     }
-    
+
+    /**
+     * Update turn counter label.
+     */
+    public void setTurnLabel(final int turnNumber)
+    {
+        turnLab.setText("Turn: " + turnNumber);
+    }
+
 }

--- a/src/main/java/soc/client/StacDBReplayClient.java
+++ b/src/main/java/soc/client/StacDBReplayClient.java
@@ -89,7 +89,7 @@ public class StacDBReplayClient extends SOCReplayClient{
 	private static final String START = "START";
 	
 	private Frame parentFrame;
-	
+
 	public void startPracticeGame(String practiceGameName, Hashtable gameOpts, boolean mainPanelIsActive)
     {
 		prCli = new DumbStringConn();
@@ -103,7 +103,12 @@ public class StacDBReplayClient extends SOCReplayClient{
     	// May take a while to start server & game.
         // The new-game window will clear this cursor.
         setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-    
+
+        // Avoid possible NPEs
+        ensureGamesParams(practiceGameName);
+        if (nickname == null)
+            setNickname(OBSERVER_DEFAULT_NAME);
+
         // Do some basic messages to start the window, which aren't in the log file
         SOCNewGameWithOptions newGame = new SOCNewGameWithOptions(practiceGameName, (String) null, -1);
         treat(newGame, true);
@@ -213,15 +218,27 @@ public class StacDBReplayClient extends SOCReplayClient{
     		System.err.println("Game name not found in DB or you passed and empty String");
     }
 	
+	@Override
 	public void pause() {
 		dtq.state = DBToQueue.PAUSE;		
 	}
+
+	@Override
 	public void play() {
 		dtq.state = DBToQueue.PLAY;
 	}
+
+	@Override
 	public void toText() {
 		dtq.state = DBToQueue.FASTFORWARD;
 	}
+
+	@Override
+	public void toTurn() {
+		// only a stub: override SOCReplayClient to avoid NPE for ftq
+	}
+
+	@Override
 	public void toBreakPoint(String breakText) {
 	    dtq.state = DBToQueue.TO_END;
 		//breaktext not needed as we are breaking based on actions not on msgs in the logs
@@ -418,7 +435,9 @@ public class StacDBReplayClient extends SOCReplayClient{
 							System.out.println("ss: " + Arrays.toString(ssFeatState));
 							System.out.println("js: " + Arrays.toString(featState));
 						}
-						
+
+						cl.setReplayTurnLabel(gameName, idCounter);
+
 					} catch (Exception e) {
 						e.printStackTrace();
 					}

--- a/src/main/java/soc/message/SOCJoinGameAuth.java
+++ b/src/main/java/soc/message/SOCJoinGameAuth.java
@@ -1,7 +1,7 @@
 /**
  * Java Settlers - An online multiplayer version of the game Settlers of Catan
  * Copyright (C) 2003  Robert S. Thomas
- * Portions of this file Copyright (C) 2010 Jeremy D Monin <jeremy@nand.net>
+ * Portions of this file Copyright (C) 2010,2020 Jeremy D Monin <jeremy@nand.net>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -107,19 +107,20 @@ public class SOCJoinGameAuth extends SOCMessage
         StringTokenizer st = new StringTokenizer(s, sep2);
 
         String ga;
-        String sd;
+        String sd = null;
         
         try
         {
             ga = st.nextToken();
-            sd = st.nextToken();
+            if (st.hasMoreTokens())
+                sd = st.nextToken();
         }
         catch (Exception e)
         {
             return null;
         }
 
-        return new SOCJoinGameAuth(ga, sd.equals("true"));
+        return new SOCJoinGameAuth(ga, "true".equals(sd));
     }
 
     /**


### PR DESCRIPTION
Hi,

This fixes a couple of more-or-less harmless NPEs I saw in StacDBReplayClient when replaying a game from the human.sql data set (for SitDown and PlayerElement messages), and a fix for the JoinGameAuth message when client joins a game on a newer server.

Thank you!