### PR TITLE
SOCReplayClient: More clearly show mode and readiness before starting replay; misc javadocs, fixes

### DIFF
--- a/src/main/java/soc/client/SOCPlayerClient.java
+++ b/src/main/java/soc/client/SOCPlayerClient.java
@@ -3345,7 +3345,9 @@ public class SOCPlayerClient extends Applet
     	SOCGame ga = (SOCGame) games.get(mes.getGame());
 
     	try {
-			logger.startLog(mes.getGame(), ga.getPlayer(getNickname()).getPlayerNumber());
+		SOCPlayer clientPlayer = ga.getPlayer(getNickname());
+		if (clientPlayer != null)
+			logger.startLog(mes.getGame(), clientPlayer.getPlayerNumber());
 		} catch (IOException e) {
 			D.ebugERROR("Failed to start the chat logger " + e.toString());
 		}

--- a/src/main/java/soc/client/SOCPlayerInterface.java
+++ b/src/main/java/soc/client/SOCPlayerInterface.java
@@ -1,7 +1,7 @@
 /**
  * Java Settlers - An online multiplayer version of the game Settlers of Catan
  * Copyright (C) 2003  Robert S. Thomas <thomas@infolab.northwestern.edu>
- * Portions of this file Copyright (C) 2007-2011 Jeremy D Monin <jeremy@nand.net>
+ * Portions of this file Copyright (C) 2007-2011,2020 Jeremy D Monin <jeremy@nand.net>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -1324,7 +1324,6 @@ public class SOCPlayerInterface extends Frame implements ActionListener, MouseLi
       {
           textInput.removeKeyListener(textInputListener);
           textInput.removeTextListener(textInputListener);
-          textInputListener.pi = null;
           textInputListener = null;
       }
         
@@ -1829,6 +1828,15 @@ public class SOCPlayerInterface extends Frame implements ActionListener, MouseLi
     {
         if (clientIsCurrentPlayer())
             getClientHand().autoRollOrPromptPlayer();
+    }
+
+    /**
+     * Clear contents of the chat input text ("please wait" during setup, etc).
+     */
+    public void clearChatTextInput()
+    {
+        textInput.setText("");
+        textInputIsInitial = false;
     }
 
     /**
@@ -2823,10 +2831,14 @@ public class SOCPlayerInterface extends Frame implements ActionListener, MouseLi
     private static class SOCPITextfieldListener
         extends KeyAdapter implements TextListener, FocusListener
     {
-        private SOCPlayerInterface pi;
+        /** our playerinterface; not null */
+        private final SOCPlayerInterface pi;
 
         public SOCPITextfieldListener(SOCPlayerInterface spi)
         {
+            if (spi == null)
+                throw new IllegalArgumentException("spi");
+
             pi = spi;
         }
 

--- a/src/main/java/soc/client/SOCReplayInterface.java
+++ b/src/main/java/soc/client/SOCReplayInterface.java
@@ -3,8 +3,11 @@ package soc.client;
 import soc.game.SOCGame;
 
 /**
- * Interface for the Replay client.  Very similar to the PlayerInterface, but uses a panel for
+ * Interface for the Replay client.  Very similar to the PlayerInterface, but uses a {@link SOCReplayPanel} for
  *  playback control instead of the Building Panel (bottom center). 
+ *<P>
+ * The game text display used by {@link SOCPlayerInterface#print(String)}
+ * is moved to the right side of the window to give it as much height as possible.
  * 
  * @author kho30
  *

--- a/src/main/java/soc/server/database/stac/StacDBHelper.java
+++ b/src/main/java/soc/server/database/stac/StacDBHelper.java
@@ -928,7 +928,7 @@ public class StacDBHelper{
 	}
 	
 	/**
-	 * Check if total pbp and total trades have been collected
+	 * Check if this game's total pbp and total trades have been collected in {@code games} table
 	 * @return
 	 */
 	public boolean areAnyTotalNumbersCollected(int gameID){


### PR DESCRIPTION
Hi,

I've used SOCReplayClient a few times and at first, the interface after loading a log was unclear to me: I wasn't sure if the log had loaded, or if some crash had occurred and that's why everything was blank.

This PR adds status text in the game text area to show the mode it's running in, and that the client is ready to start replaying. To do so, I had to rearrange methods a bit. Please let me know if I should redo or adjust anything.

I also added a javadoc reminder, based on how I ran SOCReplayClient to get data into the postgres DB from my game's soclogs:

- Game's basic info must already be in `games` overview table: id, league, season, unique name.
- Run this once to gather overall stats into trades, pbps in  games table
- Run again to create and fill game's Observable State and Game Action tables (and create an empty Extracted State table)
- Run again, adding `-eo` flag, to fill game's Extracted State table

Does this match your experience? I wouldn't want to add misleading instructions.

Thank you!
