### PR TITLE
SOCServer: Recognize robot factory originalSS mentioned in resources/config.txt, like SOCPlayerClient, Simulation

### DIFF
--- a/src/main/java/soc/server/SOCServer.java
+++ b/src/main/java/soc/server/SOCServer.java
@@ -163,6 +163,7 @@ import soc.robot.SOCRobotDMImpl;
 import soc.robot.SOCRobotFactory;
 import soc.robot.stac.MCTSRobotFactory;
 import soc.robot.stac.MCTSRobotType;
+import soc.robot.stac.OriginalSSRobotFactory;
 import soc.robot.stac.Persuasion;
 import soc.robot.stac.StacRobotDialogueManager;
 import soc.robot.stac.StacRobotBrain;
@@ -1005,6 +1006,9 @@ public class SOCServer extends Server
                     SOCRobotFactory factory = null;
                     if(p[2].contains("flatMCTS")){//soc.robot.stac.stacRobotFactory,ORIGINAL_ROBOT
                         factory = new StacRobotBrainFlatMCTS.StacRobotFlatMCTSFactory(new StacRobotType());              	
+                    }
+                    else if(p[2].contains("originalSS")){
+                        factory = new OriginalSSRobotFactory(true, new StacRobotType());
                     }
                     else if(p[2].contains("mcts")){
                         factory = new MCTSRobotFactory(true, new MCTSRobotType());              	


### PR DESCRIPTION
Currently if you launch a SOCServer from STACSettlers-1.0-bin.jar, startup includes the warning:  
`invalid robot factory: originalSS`

That factory is mentioned in src/main/java/resources/config.txt

SOCServer.setUpStacRobots has a list of recognized factories; so does SOCPlayerClient.setUpRobots and Simulation.readAgentConfiguration. Those 2 methods include originalSS but SOCServer doesn't, so this PR adds it to fix the server startup warning.

Suggestion: In the future it might make sense for someone to refactor a common "factory recognition" method from those 3 methods' code.

Thank you!